### PR TITLE
Comparissons can contain numbers

### DIFF
--- a/R/pre_process_helpers.R
+++ b/R/pre_process_helpers.R
@@ -24,7 +24,7 @@ compute_de_table <- function(adata,comp_types, test_types, obs_names,sc) {
   for (obs_name in obs_names){
     for (test_type in test_types) {
       for (comp_type in comp_types) {
-        parts <- str_match(pattern = "^\\{?([a-zA-Z\\+\\._]+)\\}?V\\{?([a-zA-Z\\+\\._]+)\\}?$",
+        parts <- str_match(pattern = "^\\{?([a-zA-Z0-9\\/\\+\\._]+)\\}?V\\{?([a-zA-Z0-9\\/\\+\\._]+)\\}?$",
                            string = comp_type)
         reference <- parts[3]
         group <- parts[2]


### PR DESCRIPTION
For the differential expression comparissons the grouup names can also contain numbers now.