### PR TITLE
Fix rendering of Feature Meta tables

### DIFF
--- a/R/mod_pg_table.R
+++ b/R/mod_pg_table.R
@@ -149,8 +149,8 @@ mod_pg_table_server <- function(id, rv_data, rv_selections, active_layer_data) {
 
       render_num_js = JS(
         "function(data, type, row, meta){",
-        "return type === 'display' ?",
-        "data.toExponential(2) : data;",
+        "return type === 'display' && data === null ?",
+        "data : data.toExponential(2);",
         "}")
 
       init_js <- JS(

--- a/R/mod_table.R
+++ b/R/mod_table.R
@@ -50,8 +50,8 @@ mod_table_server <- function(id,dt_in) {
 
       render_num_js = JS(
         "function(data, type, row, meta){",
-        "return type === 'display' ?",
-        "data.toExponential(2) : data;",
+        "return type === 'display' && data === null ?",
+        "data : data.toExponential(2);",
         "}")
 
 


### PR DESCRIPTION
A check is added if a number is null, before rendering the numbers. This should fix issue #155 .